### PR TITLE
Fix: fix known issues in production environments

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ core:
   autoSaveInterval: 30
 epubSaving:
   textDir: auto
-  layout: pre-paginated
+  layout: reflowable
   flow: auto
   spread: auto
   orientation: auto

--- a/core/app.go
+++ b/core/app.go
@@ -156,7 +156,7 @@ func (a *App) DirectLoading() Message {
 
 	returnData := a.core.agt.Exec("reader", a.core.Args)
 	if returnData.Err() != nil {
-		logger.Error(returnData.Err().Error(), logging.RunFuncName())
+		logger.Error(fmt.Sprintf("%s: %s", returnData.Err().Error(), a.core.Args), logging.RunFuncName())
 		msg.Code = 1
 		msg.Msg = returnData.Err().Error()
 		return msg

--- a/core/core.go
+++ b/core/core.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -53,7 +54,7 @@ func (c *Core) Init(assets embed.FS, app *App) *options.App {
 	// The args is the path of the epub file which is used to open the file directly.
 	ArgsLength := len(os.Args)
 	if ArgsLength > 1 {
-		c.Args = os.Args[1]
+		c.Args = strings.Join(os.Args[1:], " ")
 		c.execPath = filepath.Dir(os.Args[0])
 		currentPath = c.execPath
 	} else {

--- a/frontend/src/assets/js/utils.js
+++ b/frontend/src/assets/js/utils.js
@@ -179,6 +179,8 @@ const checkIfOpenFileDirectly = async (t) => {
         bookInfo.metadata = rawData.metadata;
         E.commands.setContent(rawData.content, false);
 
+        updateCatalog();
+
         initCover();
         loading.close();
         change.value = false;

--- a/lib/epub/writer.go
+++ b/lib/epub/writer.go
@@ -262,7 +262,7 @@ func (w *Writer) formNav() error {
 // form the text.xhtml file
 func (w *Writer) formText() error {
 	// replace the image path to the local path
-	imagePathRegex := regexp.MustCompile(`http(s)?://127.0.0.1:(\d+)/[0-9a-z]+/`)
+	imagePathRegex := regexp.MustCompile(`http(s)?://127.0.0.1:(\d+)/(\\[0-9a-z]+\\|[0-9a-z]+/)`)
 	// remove illegal characters
 	illegalCharRegex := regexp.MustCompile(`&nbsp;|&ensp;|&emsp;|&thinsp;|&zwnj;|&zwj;|&lrm;|&rlm;`)
 	w.JsonData.Content = illegalCharRegex.ReplaceAllString(w.JsonData.Content, " ")

--- a/lib/server/downloader.go
+++ b/lib/server/downloader.go
@@ -7,6 +7,7 @@ package server
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -64,6 +65,13 @@ func (downloader *ImageDownloader) Download(url string) {
 	if err != nil {
 		logger.Error(err.Error(), logging.RunFuncName())
 		downloader.Err = err
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		err = errors.New("status code error: " + resp.Status)
+		downloader.Err = err
+		logger.Error(err.Error(), logging.RunFuncName())
+		return
 	}
 	downloader.Body = resp.Body
 	downloader.generateName()


### PR DESCRIPTION
Further paragraphs come after blank lines.
- Modify the validation logic for the download fetch request body in the download middleware in lib/server so that it will terminate in time after throwing an exception.
- Modify the logic of getting software parameters in core to get all parameters after the first parameter and splice them into a complete filename.
- Add the updateCatalog method to the checkIfOpenFileDirectly method in the frontend utils file to refresh the catalog after opening a file.
- Modify the regular expression in lib/epub's writer that handles image links to match the presence of backslashes in paths.
- Modify the default configuration items in config.yaml.

Bugs that fix:
- When a network error occurs when downloading an image, the error is not truncated causing the program to crash.
- When there are spaces in the epub file name, the file name is incomplete when openning the file directly.
- Directly open the file and the directory is not refreshed.
- Save the wrong image path when saving the epub.